### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/io.github.radiolamp.mangojuice.yml
+++ b/io.github.radiolamp.mangojuice.yml
@@ -16,13 +16,12 @@ finish-args:
   - --filesystem=xdg-config/MangoHud:create
 cleanup:
   - /include
+  - /lib/cmake
   - /lib/pkgconfig
-  - /man
+  - /share/cmake
   - /share/doc
-  - /share/gtk-doc
   - /share/man
   - /share/pkgconfig
-  - /share/vala
   - '*.la'
   - '*.a'
 modules:


### PR DESCRIPTION
- Drop ineffective cleanup commands
- Improve cleanup commands to reduce the Flatpak size

**Please don't forget to test before merging. I'm not familiar with MangoHud or this app.**